### PR TITLE
Ignore PermissionError when iter dirs

### DIFF
--- a/kindle_sdr_cleaner.py
+++ b/kindle_sdr_cleaner.py
@@ -9,22 +9,25 @@ def handle_path(path: Path):
     subfolders = []
     seen_sdrs = set()
     seen_files = set()
-    for entry in path.iterdir():
-        if entry.is_dir():
-            if entry.suffix == ".sdr":
-                seen_sdrs.add(entry.stem)
+    try:
+        for entry in path.iterdir():
+            if entry.is_dir():
+                if entry.suffix == ".sdr":
+                    seen_sdrs.add(entry.stem)
+                else:
+                    subfolders.append(entry)
             else:
-                subfolders.append(entry)
-        else:
-            # is file
-            seen_files.add(entry.stem)
-    diff = seen_sdrs - seen_files
-    for sdr_to_remove in diff:
-        sdr_path = path / f"{sdr_to_remove}.sdr"
-        print("Remove: ", sdr_path)
-        shutil.rmtree(sdr_path)
-    for folder in subfolders:
-        handle_path(folder)
+                # is file
+                seen_files.add(entry.stem)
+        diff = seen_sdrs - seen_files
+        for sdr_to_remove in diff:
+            sdr_path = path / f"{sdr_to_remove}.sdr"
+            print("Remove: ", sdr_path)
+            shutil.rmtree(sdr_path)
+        for folder in subfolders:
+            handle_path(folder)
+    except PermissionError:
+        print("PermissionError: ", path, ", skip")
 
 
 def main():


### PR DESCRIPTION
When a kindle is connected to a Mac computer, some hidden dirs will be created automatically.

These dirs make this tool crash:

```
Traceback (most recent call last):
  File "../code/kindle_sdr_cleaner.py", line 39, in <module>
    main()
  File "../code/kindle_sdr_cleaner.py", line 35, in main
    handle_path(Path.cwd())
  File "../code/kindle_sdr_cleaner.py", line 27, in handle_path
    handle_path(folder)
  File "../code/kindle_sdr_cleaner.py", line 12, in handle_path
    for entry in path.iterdir():
  File "/Users/chenfeng/opt/anaconda3/lib/python3.8/pathlib.py", line 1121, in iterdir
    for name in self._accessor.listdir(self):
PermissionError: [Errno 1] Operation not permitted: '/Volumes/Kindle/.Spotlight-V100'
```

After this fix, it runs OK:

```
PermissionError:  /Volumes/Kindle/.Spotlight-V100 , skip
PermissionError:  /Volumes/Kindle/.Trashes , skip
```